### PR TITLE
update askForPassword() to match 0.6.2

### DIFF
--- a/src/MinimalNotify.cpp
+++ b/src/MinimalNotify.cpp
@@ -53,7 +53,7 @@ char *getpass (const char *prompt)
 }
 #endif
 
-bool NotifyTxt::askForPassword(const std::string& key_details, bool /*prev_is_bad*/, std::string& password, bool& cancel)
+bool NotifyTxt::askForPassword(const std::string& title, const std::string& question, bool /*prev_is_bad*/, std::string& password, bool& cancel)
 {
 	char *passwd = getpass(("Please enter GPG password for key "+key_details+": ").c_str()) ;
 	password = passwd;

--- a/src/MinimalNotify.h
+++ b/src/MinimalNotify.h
@@ -17,7 +17,8 @@
 class NotifyTxt : public NotifyClient
 {
 public:
-	virtual bool askForPassword(const std::string& key_details, bool prev_is_bad, std::string& password, bool& cancel);
+	//virtual bool askForPassword(                      const std::string& key_details, bool prev_is_bad,       std::string& password, bool& cancel);
+	virtual bool askForPassword(const std::string& title, const std::string& question, bool /* prev_is_bad */, std::string& password, bool& cancel);
 };
 
 #endif /* MINIMALNOTIFY_H_ */


### PR DESCRIPTION
askForPassword() is outdate.
ChatServer will fail without asking for GPG passphrase.

fixed.

go to ~/RetroShare/ChatServer/src and type
>qmake && make

ChatServer is not included in the main project makefiles, you have to go to the ChatServer/src and make a new makefile by qmake.

ChatServer is depending on nogui libraries, so you also have to run library installation in ~/RetroShare/
>qmake
>make retroshare_nogui  (this is _ not -)
>sudo make retroshare_nogui-install_subtargets

The WebUI is not copied to /usr/share/RetroShare06/webui/ as well, you have to do it manually, from somewhere else, for example from PC version?

-------------------------------------------------------------
With new WebUI APIs, ChatServer BackEnd is actually no necessary anymore. It's possible to run a ChatServer with nogui+WebUI+ChatServerFrontEnd, The FrontEnd can simply call the WebUI API and pass the new Certificate to it.